### PR TITLE
Adding importers + small touches

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -33,7 +33,12 @@ func servePost(w http.ResponseWriter, r *http.Request) error {
 }
 
 func servePosts(w http.ResponseWriter, r *http.Request) error {
-	posts, err := apiClient.Posts.List(&bogthesrc.PostListOptions{})
+	var opt bogthesrc.PostListOptions
+	if err := schema.NewDecoder().Decode(&opt, r.URL.Query()); err != nil {
+		return err
+	}
+
+	posts, err := apiClient.Posts.List(&opt)
 	if err != nil {
 		return err
 	}

--- a/app/template.go
+++ b/app/template.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -62,6 +63,7 @@ func parseTemplates(sets [][]string) error {
 		tmpl.Funcs(htmpl.FuncMap{
 			"urlTo":     urlTo,
 			"urlDomain": urlDomain,
+			"itoa":      strconv.Itoa,
 		})
 
 		_, err := tmpl.ParseFiles(files...)

--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ func (lo ListOptions) Offset() int {
 const (
 	version        = "0.0.1"
 	userAgent      = "bogthesrc-client" + version
-	DefaultPerPage = 10
+	DefaultPerPage = 60
 )
 
 // NewClient

--- a/datastore/post.go
+++ b/datastore/post.go
@@ -2,14 +2,20 @@ package datastore
 
 import (
 	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
 
 	"github.com/bogthe/bogthesrc"
+	"github.com/jmoiron/modl"
 )
 
 func init() {
 	DB.AddTableWithName(bogthesrc.Post{}, "post").SetKeys(true, "ID")
 	createSql = append(createSql,
 		`CREATE INDEX post_submittedat ON post(submittedat DESC);`,
+		`CREATE UNIQUE INDEX post_linkurl ON post(link);`,
 	)
 }
 
@@ -35,7 +41,46 @@ func (s *PostStore) Get(id string) (*bogthesrc.Post, error) {
 }
 
 func (s *PostStore) Create(post *bogthesrc.Post) error {
-	return s.dbh.Insert(post)
+	retry := 0
+	shouldRetry := false
+	var reason error
+
+	for retry < 3 {
+		err := transact(s.dbh, func(tx modl.SqlExecutor) error {
+			var existing []*bogthesrc.Post
+			if err := tx.Select(&existing, `SELECT * FROM post WHERE link=$1 LIMIT 1;`, post.Link); err != nil {
+				return err
+			}
+
+			if len(existing) > 0 {
+				*post = *existing[0]
+				return nil
+			}
+
+			if err := tx.Insert(post); err != nil {
+				if strings.Contains(err.Error(), `violates unique constraint "post_linkurl"`) {
+					time.Sleep(time.Duration(rand.Intn(75)) * time.Millisecond)
+					shouldRetry = true
+					return err
+				}
+				return err
+			}
+
+			return nil
+		})
+
+		if !shouldRetry {
+			return nil
+		}
+
+		if err != nil && reason == nil {
+			reason = err
+		}
+
+		retry++
+	}
+
+	return fmt.Errorf("Couldn't insert post %+v, reason: %s", post, reason)
 }
 
 func (s *PostStore) List(opt *bogthesrc.PostListOptions) ([]*bogthesrc.Post, error) {

--- a/importer/hacker_news.go
+++ b/importer/hacker_news.go
@@ -1,0 +1,95 @@
+package importer
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/bogthe/bogthesrc"
+)
+
+type hackerNews struct {
+	which string
+}
+
+const (
+	base     = "https://hacker-news.firebaseio.com/v0/%s.json"
+	describe = "https://hacker-news.firebaseio.com/v0/item/%v.json"
+)
+
+func init() {
+	Fetchers = append(Fetchers, &hackerNews{"topstories"}, &hackerNews{"newstories"}, &hackerNews{"beststories"})
+}
+
+func (h *hackerNews) Fetch() ([]*bogthesrc.Post, error) {
+	ids, err := getIds(fmt.Sprintf(base, h.which))
+	if err != nil {
+		return nil, err
+	}
+
+	posts := make([]*bogthesrc.Post, 0)
+	for _, id := range ids {
+		post, err := getPost(fmt.Sprintf(describe, id))
+		if err != nil {
+			return nil, err
+		}
+
+		if post == nil {
+			continue
+		}
+
+		posts = append(posts, post)
+	}
+
+	return posts, nil
+}
+
+func (h *hackerNews) Site() string {
+	return fmt.Sprintf("hackernews/%s", h.which)
+}
+
+func getPost(url string) (*bogthesrc.Post, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var hn *struct {
+		Title string
+		Score int
+		Url   string
+		Type  string
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&hn); err != nil {
+		return nil, err
+	}
+
+	if hn.Type != "story" || hn.Url == "" {
+		return nil, nil
+	}
+
+	return &bogthesrc.Post{
+		Title: hn.Title,
+		Score: hn.Score,
+		Link:  hn.Url,
+	}, nil
+}
+
+func getIds(url string) ([]int, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var ids []int
+	if err := json.NewDecoder(resp.Body).Decode(&ids); err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -1,0 +1,33 @@
+package importer
+
+import (
+	"github.com/bogthe/bogthesrc"
+)
+
+type Fetcher interface {
+	Fetch() ([]*bogthesrc.Post, error)
+	Site() string
+}
+
+var (
+	Fetchers []Fetcher
+
+	apiClient = bogthesrc.NewApiClient(nil)
+)
+
+func Import(f Fetcher) []error {
+	posts, err := f.Fetch()
+	if err != nil {
+		return []error{err}
+	}
+
+	errors := make([]error, 0)
+	for _, post := range posts {
+		err := apiClient.Posts.Create(post)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	return errors
+}

--- a/posts.go
+++ b/posts.go
@@ -13,6 +13,7 @@ type Post struct {
 	Link        string
 	Body        string
 	SubmittedAt time.Time
+	Score       int
 	AuthordID   int
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -74,7 +74,7 @@ body > section.main {
 
 form.create-post dl { margin: 0; padding: 0; }
 form.create-post dt {
-    
+
 }
 form.create-post dt label {
     font-weight: bold;
@@ -95,9 +95,18 @@ form.create-post button {
 }
 
 /* posts */
+ol.posts {
+    margin: 0; padding: 0;
+    list-style-type: none;
+}
 li.post {
     margin-bottom: 8px;
     color: #aaa;
+    clear: both;
+}
+li.post div.post {
+    margin-left: 38px;
+    padding-left: 10px;
 }
 li.post .post-link {
     color: #468cbf;
@@ -109,11 +118,38 @@ li.post .post-link:hover {
 }
 li.post .post-link:visited { color: #777; }
 li.post .domain {
-    color: #888;
+    color: #999;
     font-size: 0.75em;
 }
 li.post .post-body {
-    margin: 0; padding: 0;
-    font-size: 0.85em;
-    color: #444;
+    margin: 4px 0 0 0;
+    font-size: 0.82em;
+    color: #666;
+    max-width: 600px;
 }
+li.post .post-info, li.post .post-info li { margin: 0; padding: 0; }
+li.post { position: relative; }
+li.post .post-info {
+    float: left;
+    width: 38px;
+    text-align: right;
+}
+li.post .post-info li {
+    list-style-type: none;
+    margin-bottom: 3px;
+}
+li.post .post-info li a {
+    display: inline-block;
+    text-align: center;
+    width: 25px;
+    color: #777;
+    border-radius: 3px;
+    border: solid 1px #e7e7e7;
+    background-color: #f3f3f3;
+    padding: 2px;
+    font-size: 0.75em;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: visible;
+}
+

--- a/tmpl/post/list.html
+++ b/tmpl/post/list.html
@@ -3,8 +3,15 @@
 
 {{define "Main"}}
 <ol class="posts">
-    {{range .Posts}}
-    <li class="post">{{template "Post" .}}</li>
+    {{range $i, $post := .Posts}}
+    <li class="post">
+        <ul class="post-info">
+            <li class="score">
+                <a href="{{urlTo "post" "ID" (itoa .ID)}}">{{.Score}} &#9733;</a>
+            </li>
+        </ul>
+        <div class="post">{{template "Post" $post}}</div>
+    </li>
     {{end}}
 </ol>
 {{end}}


### PR DESCRIPTION
By Merlin's beard! We've added the importers, HackerNews API isn't the
greatest but it was still easy to work with, and I'm sure it's easy for
them to maintain `https://github.com/HackerNews/API`. Importers are
pretty straight forward with regards to what they do. Currently we're
using the API Client as maybe at one point I see the importers split
into a separate service